### PR TITLE
Fixed a wrong method call in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Spacing out multiple views:
 // space out views horizontally with 20 points in between
 [UIView spaceOutViewsHorizontally:views predicate:@"20"];
 // space out views vertically with no space in between
-[UIView spaceOutViewsHorizontally:views predicate:nil];
+[UIView spaceOutViewsVertically:views predicate:nil];
 
 // Distribute views according to their horizontal center
 [UIView distributeCenterXOfViews:views inView:containerView];


### PR DESCRIPTION
In the space out views vertically example the horizontal class method was being called.
