### PR TITLE
Add documentation comments for the first group of methods

### DIFF
--- a/FLKAutoLayout/UIView+FLKAutoLayout.h
+++ b/FLKAutoLayout/UIView+FLKAutoLayout.h
@@ -9,16 +9,77 @@
 
 @interface UIView (FLKAutoLayout)
 
+///---------------------------------------
+/// @name Aligning layout attributes
+///---------------------------------------
+
+/**
+  Align a layout attribute of a view to a layout attribute of a different view
+  @param attribute   The attribute to align
+  @param toAttribute The attribute to align to
+  @param view        The view of the attribute to align to
+  @param predicate   A predicate to use for alignment
+  @return An array of NSLayoutConstraint objects to the view
+ */
 - (NSArray*)alignAttribute:(NSLayoutAttribute)attribute toAttribute:(NSLayoutAttribute)toAttribute ofView:(UIView*)view predicate:(NSString*)predicate;
 
+///---------------------------------------
+/// @name Aligning to a view
+///---------------------------------------
 
+/**
+  Align a view to another view
+  @param view The view to align the view to
+  @return An array of NSLayoutConstraint objects applied to the view
+ */
 - (NSArray*)alignToView:(UIView*)view;
-- (NSArray*)alignTop:(NSString*)top leading:(NSString*)leading bottom:(NSString*)bottom trailing:(NSString*)trailing toView:(UIView*)view;
-- (NSArray*)alignTop:(NSString*)top leading:(NSString*)leading toView:(UIView*)view;
-- (NSArray*)alignBottom:(NSString*)bottom trailing:(NSString*)trailing toView:(UIView*)view;
-- (NSArray*)alignTop:(NSString*)top bottom:(NSString*)bottom toView:(UIView*)view;
-- (NSArray*)alignLeading:(NSString*)leading trailing:(NSString*)trailing toView:(UIView*)view;
 
+/**
+  Align a view to another view
+  @param top      The offset for the top alignment
+  @param leading  The offset for the leading alignment
+  @param bottom   The offset for the bottom alignment
+  @param trailing The offset for the trailing alignment
+  @param view     The view to align to
+  @return An array of NSLayoutConstraint objects applied to the view
+ */
+- (NSArray*)alignTop:(NSString*)top leading:(NSString*)leading bottom:(NSString*)bottom trailing:(NSString*)trailing toView:(UIView*)view;
+
+/**
+  Align a view to another view
+  @param top     The offset for the top alignment
+  @param leading The offset for the leading alignment
+  @param view    The view to align to
+  @return An array of NSLayoutConstraint objects applied to the view
+ */
+- (NSArray*)alignTop:(NSString*)top leading:(NSString*)leading toView:(UIView*)view;
+
+/**
+  Align a view
+  @param bottom   The offset for the bottom alignment
+  @param trailing The offset for the trailing alignment
+  @param view     The view to align to
+  @return An array of NSLayoutConstraint objects applied to the view
+ */
+- (NSArray*)alignBottom:(NSString*)bottom trailing:(NSString*)trailing toView:(UIView*)view;
+
+/**
+  Align a view
+  @param top    The offset for the top alignment
+  @param bottom The offset for the bottom alignment
+  @param view   The view to align to
+  @return An array of NSLayoutConstraint objects applied to the view
+ */
+- (NSArray*)alignTop:(NSString*)top bottom:(NSString*)bottom toView:(UIView*)view;
+
+/**
+  Align a view to another view
+  @param leading  The offset for the leading alignment
+  @param trailing The offset for the trailing alignment
+  @param view     The view to align to
+  @return An array of NSLayoutConstraint objects applied to the view
+ */
+- (NSArray*)alignLeading:(NSString*)leading trailing:(NSString*)trailing toView:(UIView*)view;
 
 - (NSArray*)alignLeadingEdgeWithView:(UIView*)view predicate:(NSString*)predicate;
 - (NSArray*)alignTrailingEdgeWithView:(UIView*)view predicate:(NSString*)predicate;


### PR DESCRIPTION
I wrote up a few appledoc style documentation comments for the first set of methods. I find these to be useful when using the in context documentation browser in Xcode, which appears when alt clicking on a method. In particular, I like being able to see the object type of an input parameter (similar to how methods in Apple libraries appear in the documentation browser), or what type of object an array contains, without having to open the library in a new tab or the assistant editor. It helps me to stay in the flow while programming.