### PR TITLE
Added UIKit header to prevent compilation error

### DIFF
--- a/FLKAutoLayout/UIView+FLKAutoLayout.h
+++ b/FLKAutoLayout/UIView+FLKAutoLayout.h
@@ -6,7 +6,7 @@
 
 
 #import <Foundation/Foundation.h>
-
+#import <UIKit/UIKit.h>
 
 FOUNDATION_EXTERN NSString * const FLKNoConstraint;
 


### PR DESCRIPTION
Using the library as-is with CocoaPods, after adding `#import <FLKAutoLayout/UIView+FLKAutoLayout.h>` to my source files I get an error "Cannot find interface declaration for UIView". This commit solves this issue.