### PR TITLE
FLKAutoLayout cannot be used with Swift 1.2

### DIFF
--- a/FLKAutoLayout/UIView+FLKAutoLayout.h
+++ b/FLKAutoLayout/UIView+FLKAutoLayout.h
@@ -5,7 +5,7 @@
 //
 
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 
 FOUNDATION_EXTERN NSString * const FLKNoConstraint;


### PR DESCRIPTION
The compiler complains about not being able to find `UIView`. Replacing Foundation with UIKit resolves the problem.