### PR TITLE
Debug Autolayout constraints description

### DIFF
--- a/FLKAutoLayout/NSLayoutConstraint+FLKAutoLayoutDebug.m
+++ b/FLKAutoLayout/NSLayoutConstraint+FLKAutoLayoutDebug.m
@@ -24,7 +24,10 @@
 {
     NSString *description = super.description;
     NSString *asciiArtDescription = self.asciiArtDescription;
-    return [description stringByAppendingFormat:@" %@ (%@, %@)", asciiArtDescription, [self.firstItem flk_nameTag], [self.secondItem flk_nameTag]];
+    NSString *firstItemTag = [self.firstItem isKindOfClass:[UIView class]] ? [self.firstItem flk_nameTag] : @"";
+    NSString *secondItemTag = [self.secondItem isKindOfClass:[UIView class]] ? [self.secondItem flk_nameTag] : @"";
+    
+    return [description stringByAppendingFormat:@" %@ (%@, %@)", asciiArtDescription, firstItemTag, secondItemTag];
 }
 
 #endif


### PR DESCRIPTION
UILayoutGuide was called as firstItem or secondItem. This class doesn't have UIView as class parent and won't have the method "-(NSString *)flk_nameTag" from the category "UIView+FLKAutoLayoutDebug.h".