### PR TITLE
bugfix: constrainAspectRatio is not working if the view does not have parent

### DIFF
--- a/FLKAutoLayout/UIView+FLKAutoLayoutPredicate.m
+++ b/FLKAutoLayout/UIView+FLKAutoLayoutPredicate.m
@@ -46,7 +46,7 @@ FLKAutoLayoutPredicate FLKAutoLayoutPredicateMake(NSLayoutRelation relation, CGF
 }
 
 - (UIView*)commonSuperviewWithView:(UIView*)view {
-    if (!view) {
+    if (!view || self == view) {
         return self;
     } else if (self.superview == view) {
         return view;


### PR DESCRIPTION
The constrain could be added directly to the view if both views are the same?