### PR TITLE
Don't crash on invalid constraints

### DIFF
--- a/FLKAutoLayout/UIView+FLKAutoLayoutDebug.h
+++ b/FLKAutoLayout/UIView+FLKAutoLayoutDebug.h
@@ -16,3 +16,9 @@
 - (NSString *)flk_autolayoutTrace;
 
 @end
+
+@interface UILayoutGuide (FLKAutoLayoutDebug)
+
+@property (nonatomic, strong) NSString *flk_nameTag;
+
+@end

--- a/FLKAutoLayout/UIView+FLKAutoLayoutDebug.m
+++ b/FLKAutoLayout/UIView+FLKAutoLayoutDebug.m
@@ -56,3 +56,17 @@ static char *const NameTagKey = "flk_nameTag";
 }
 
 @end
+
+@implementation UILayoutGuide (FLKAutoLayoutDebug)
+
+- (NSString *)flk_nameTag
+{
+    return objc_getAssociatedObject(self, NameTagKey);
+}
+
+- (void)setFlk_nameTag:(NSString *)nameTag
+{
+    objc_setAssociatedObject(self, NameTagKey, nameTag, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+@end


### PR DESCRIPTION
Fixes exceptions of the sort:

> -[UILayoutGuide flk_nameTag]: unrecognized selector sent to instance 0x7ffe2bff9470
> *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[UILayoutGuide flk_nameTag]: unrecognized selector sent to instance 0x7ffe2bff9470'
> *** First throw call stack:
> (
> 	0   CoreFoundation                      0x000000010c6acd85 __exceptionPreprocess + 165
> 	1   libobjc.A.dylib                     0x000000010c120deb objc_exception_throw + 48
> 	2   CoreFoundation                      0x000000010c6b5d3d -[NSObject(NSObject) doesNotRecognizeSelector:] + 205
> 	3   CoreFoundation                      0x000000010c5fbcfa ___forwarding___ + 970
> 	4   CoreFoundation                      0x000000010c5fb8a8 _CF_forwarding_prep_0 + 120
> 	5   FLKAutoLayout                       0x0000000109046958 -[NSLayoutConstraint(FLKAutoLayoutDebug) description] + 168
> 	6   CoreFoundation                      0x000000010c69cd28 -[NSArray descriptionWithLocale:indent:] + 344
> 	7   Foundation                          0x000000010906c5fc _NSDescriptionWithLocaleFunc + 64
> 	8   CoreFoundation                      0x000000010c598bdc __CFStringAppendFormatCore + 9708
> 	9   CoreFoundation                      0x000000010c688a03 _CFStringCreateWithFormatAndArgumentsAux2 + 259
> 	10  CoreFoundation                      0x000000010c69993a _CFLogvEx2 + 154
> 	11  CoreFoundation                      0x000000010c699a9b _CFLogvEx3 + 171
> 	12  Foundation                          0x0000000109143b1e _NSLogv + 117
> 	13  Foundation                          0x0000000109092822 NSLog + 152
> 	14  UIKit                               0x000000010b0a3885 UIViewAlertForUnsatisfiableConstraints + 779
> 	15  UIKit                               0x000000010b0a3966 -[UIView(UIConstraintBasedLayout_EngineDelegate) engine:willBreakConstraint:dueToMutuallyExclusiveConstraints:] + 113
> 	16  Foundation                          0x000000010923debf -[NSISEngine handleUnsatisfiableRowWithHead:body:usingInfeasibilityHandlingBehavior:mutuallyExclusiveConstraints:] + 489
> 	17  Foundation                          0x000000010909ded5 -[NSISEngine fixUpValueRestrictionViolationsWithInfeasibilityHandlingBehavior:] + 613
> 	18  Foundation                          0x000000010923eab7 -[NSISEngine _optimizeWithoutRebuilding] + 134
> 	19  Foundation                          0x000000010909dc0f -[NSISEngine optimize] + 46
> 	20  Foundation                          0x00000001090a4875 -[NSISEngine constraintDidChangeSuchThatMarker:shouldBeReplacedByMarkerPlusDelta:] + 313
> 	21  Foundation                          0x00000001090a46f2 -[NSISEngine tryToChangeConstraintSuchThatMarker:isReplacedByMarkerPlusDelta:undoHandler:] + 440
> 	22  Foundation                          0x0000000109090715 -[NSLayoutConstraint _tryToChangeContainerGeometryWithUndoHandler:] + 484
> 	23  Foundation                          0x0000000109090274 -[NSLayoutConstraint _setSymbolicConstant:constant:] + 422
> 	24  UIKit                               0x000000010a83edcc -[UIView _updateLayoutMarginsGuideConstraintsIfApplicable] + 529
> 	25  UIKit                               0x000000010a83ef5d -[UIView _layoutMarginsDidChange] + 100
> 	26  UIKit                               0x000000010a83f735 -[UIView _updateInferredLayoutMargins] + 1740
> 	27  UIKit                               0x000000010a84f4ce -[UIView(Geometry) setBounds:] + 2380
> 	28  UIKit                               0x000000010a84e6b2 -[UIView(Geometry) _applyISEngineLayoutValues] + 477
> 	29  UIKit                               0x000000010a84e9e2 -[UIView(Geometry) _resizeWithOldSuperviewSize:] + 127
> 	30  CoreFoundation                      0x000000010c5d4d32 __53-[__NSArrayM enumerateObjectsWithOptions:usingBlock:]_block_invoke + 114
> 	31  CoreFoundation                      0x000000010c5d44af -[__NSArrayM enumerateObjectsWithOptions:usingBlock:] + 335
> 	32  UIKit                               0x000000010a84d2f3 -[UIView(Geometry) resizeSubviewsWithOldSize:] + 184
> 	33  UIKit                               0x000000010b09b2bb -[UIView(AdditionalLayoutSupport) _is_layout] + 167
> 	34  UIKit                               0x000000010a853cfa -[UIView(Hierarchy) _updateConstraintsAsNecessaryAndApplyLayoutFromEngine] + 771
> 	35  UIKit                               0x000000010a863980 -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 703
> 	36  QuartzCore                          0x000000010a31cc00 -[CALayer layoutSublayers] + 146
> 	37  QuartzCore                          0x000000010a31108e _ZN2CA5Layer16layout_if_neededEPNS_11TransactionE + 366
> 	38  QuartzCore                          0x000000010a310f0c _ZN2CA5Layer28layout_and_display_if_neededEPNS_11TransactionE + 24
> 	39  QuartzCore                          0x000000010a3053c9 _ZN2CA7Context18commit_transactionEPNS_11TransactionE + 277
> 	40  QuartzCore                          0x000000010a333086 _ZN2CA11Transaction6commitEv + 486
> 	41  UIKit                               0x000000010a7d519b _afterCACommitHandler + 174
> 	42  CoreFoundation                      0x000000010c5d1c37 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 23
> 	43  CoreFoundation                      0x000000010c5d1ba7 __CFRunLoopDoObservers + 391
> 	44  CoreFoundation                      0x000000010c5c77fb __CFRunLoopRun + 1147
> 	45  CoreFoundation                      0x000000010c5c70f8 CFRunLoopRunSpecific + 488
> 	46  GraphicsServices                    0x000000010e70aad2 GSEventRunModal + 161
> 	47  UIKit                               0x000000010a7a8f09 UIApplicationMain + 171
> 	48  Sportle                             0x0000000106ab6cdf main + 367
> 	49  libdyld.dylib                       0x000000010ddec92d start + 1
> 	50  ???                                 0x0000000000000001 0x0 + 1
> )