### PR TITLE
@Florian => Fix the example app, fixes #17 #39 #33

### DIFF
--- a/Example/FLKAutoLayout/FLKAppDelegate.m
+++ b/Example/FLKAutoLayout/FLKAppDelegate.m
@@ -1,11 +1,3 @@
-//
-//  FLKAppDelegate.m
-//  FLKAutoLayout
-//
-//  Created by Orta Therox on 04/12/2016.
-//  Copyright (c) 2016 Orta Therox. All rights reserved.
-//
-
 #import "FLKAppDelegate.h"
 
 @implementation FLKAppDelegate
@@ -14,33 +6,6 @@
 {
     // Override point for customization after application launch.
     return YES;
-}
-
-- (void)applicationWillResignActive:(UIApplication *)application
-{
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-}
-
-- (void)applicationDidEnterBackground:(UIApplication *)application
-{
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-}
-
-- (void)applicationWillEnterForeground:(UIApplication *)application
-{
-    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-}
-
-- (void)applicationDidBecomeActive:(UIApplication *)application
-{
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
 @end

--- a/Example/FLKAutoLayout/FLKViewController.m
+++ b/Example/FLKAutoLayout/FLKViewController.m
@@ -60,7 +60,7 @@
     
     [boxViews[0] constrainWidth:@"100" height:@"100"];
     [UIView equalWidthForViews:boxViews];
-    id array = [UIView equalHeightForViews:boxViews];
+    [UIView equalHeightForViews:boxViews];
     [boxViews[0] alignCenterXWithView:leftBlock predicate:@"0"];
     [UIView alignLeadingAndTrailingEdgesOfViews:boxViews];
     [UIView distributeCenterYOfViews:boxViews inView:boxContainer];
@@ -114,7 +114,6 @@
     [UIView alignBottomEdgesOfViews:buttonViews];
     [UIView distributeCenterXOfViews:buttonViews inView:buttonContainer];
 
-
     UIView *test1 = [[UIView alloc] init];
     [backgroundView addSubview:test1];
     [test1 constrainWidth:@"400" height:@"200"];
@@ -154,7 +153,7 @@
 
     [test4 alignTop:@"0" bottom:@"0" toView:test3];
     [test4 constrainWidth:@"2"];
-    [test4 alignAttribute:NSLayoutAttributeLeft toAttribute:NSLayoutAttributeRight ofView:test2 predicate:@"*0"];
+    [test4 alignAttribute:NSLayoutAttributeLeft toAttribute:NSLayoutAttributeRight ofView:test2 predicate:@"0"];
 }
 
 

--- a/FLKAutoLayout/UIView+FLKAutoLayout.m
+++ b/FLKAutoLayout/UIView+FLKAutoLayout.m
@@ -276,7 +276,7 @@ typedef NSArray *(^viewChainingBlock)(UIView *view1, UIView *view2);
 {
     NSAssert(views.count > 1, @"Distribute views requires at least two views");
     CGFloat interval = 2.0f / (views.count - 1);
-    CGFloat multiplier = 0;
+    CGFloat multiplier = 0.01;
     NSMutableArray *constraints = [NSMutableArray array];
     for (UIView *view in views) {
         FLKAutoLayoutPredicate predicate = FLKAutoLayoutPredicateMake(NSLayoutRelationEqual, multiplier, 0, 0);


### PR DESCRIPTION
I'll save this one for a patch release, and get 1.0.0 out - so this isn't blocking. 

I'm interested in the ramifications here:

``` diff
-    CGFloat multiplier = 0;
+    CGFloat multiplier = 0.01;
```

It seems reasonable to think when FLKAutoLayout was written Auto Layout would accept a multiplier of `0` in constraints - but since then, maybe since iOS8? The API does not allow using a 0 as the multiplier - which causes crashes in the example app, and assumably in all of the app code ( I don't see any uses of `distributeCenterXOfViews` or the others in Eigen, I expect because of this. )

Can you think of a better way to do this, and/or do you think this would cause issues?

/cc @alloy if you want to have a think too