### PR TITLE
Assert on predicates that would return nil

### DIFF
--- a/FLKAutoLayout/Private/FLKAutoLayoutPredicateList.m
+++ b/FLKAutoLayout/Private/FLKAutoLayoutPredicateList.m
@@ -61,6 +61,8 @@
     if (priorityRange.location != NSNotFound) {
         predicate.priority = [[string substringWithRange:priorityRange] integerValue];
     }
+
+    NSAssert(predicate.priority < UILayoutPriorityRequired, @"Due to FLKAutoLayout's nullability API, priorities over 1000 ( which would fail and return null ) are not supported.");
     [predicates addObject:[NSValue valueWithBytes:&predicate objCType:@encode(FLKAutoLayoutPredicate)]];
 }
 

--- a/FLKAutoLayout/Private/UIView+FLKAutoLayoutPredicate.m
+++ b/FLKAutoLayout/Private/UIView+FLKAutoLayoutPredicate.m
@@ -19,7 +19,7 @@ FLKAutoLayoutPredicate FLKAutoLayoutPredicateMake(NSLayoutRelation relation, CGF
 }
 
 - (NSLayoutConstraint *)applyPredicate:(FLKAutoLayoutPredicate)predicate toView:(id)viewOrLayoutGuide fromAttribute:(NSLayoutAttribute)fromAttribute toAttribute:(NSLayoutAttribute)toAttribute {
-    if (predicate.priority > UILayoutPriorityRequired) return nil;
+    NSAssert(predicate.priority < UILayoutPriorityRequired, @"Due to FLKAutoLayout's nullability API, priorities over 1000 ( which would fail and return null ) are not supported.");
 
     UIView *view;
     id toItem;

--- a/FLKAutoLayout/UIView+FLKAutoLayout.h
+++ b/FLKAutoLayout/UIView+FLKAutoLayout.h
@@ -1,13 +1,11 @@
 @import UIKit;
 NS_ASSUME_NONNULL_BEGIN
 
-FOUNDATION_EXTERN NSString *const FLKNoConstraint;
-
 /// A collection of categories for UIViews, note the
 /// `view` API can either be a `UIView` subclass or a `FLKAutoLayoutGuide`.
 
 @interface UIView (FLKAutoLayout)
-
+ 
 #pragma mark Generic constraint methods for two views
 
 /// Align an attribute of one view to another.

--- a/FLKAutoLayout/UIView+FLKAutoLayout.m
+++ b/FLKAutoLayout/UIView+FLKAutoLayout.m
@@ -1,8 +1,6 @@
 #import "UIView+FLKAutoLayout.h"
 #import "FLKAutoLayoutPredicateList.h"
 
-NSString *const FLKNoConstraint = @"0@1001"; // maximum valid priority is 1000, constraints with a priority > 1000 will be ignored by FLKAutoLayout
-
 typedef NSArray *(^viewChainingBlock)(UIView *view1, UIView *view2);
 
 


### PR DESCRIPTION
FLKAutoLayout supported an interesting feature of Auto Layout that would let you create predicates that would not be applied due to too high of a priority, this breaks all the nullability checks in 1.0 alas, and so is removed via runtime asserts.

Re #49 