### PR TITLE
Fix for “Use of '@import' when modules are disabled”.

### DIFF
--- a/FLKAutoLayout.podspec
+++ b/FLKAutoLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FLKAutoLayout"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.platform     = :ios, '7.0'
   s.summary      = "UIView category which makes it easy to create layout constraints in code."
   s.description  = "A collection of UIView category methods to make it easy when creating layout constraints in code."

--- a/FLKAutoLayout/NSObject+FLKAutoLayoutDebug.h
+++ b/FLKAutoLayout/NSObject+FLKAutoLayoutDebug.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface NSObject (FLKAutoLayoutDebug)
 

--- a/FLKAutoLayout/Private/FLKAutoLayoutPredicateList.h
+++ b/FLKAutoLayout/Private/FLKAutoLayoutPredicateList.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 #import "UIView+FLKAutoLayoutPredicate.h"
 
 typedef NSLayoutConstraint *(^predicateBlock)(FLKAutoLayoutPredicate predicate);

--- a/FLKAutoLayout/Private/NSLayoutConstraint+FLKAutoLayoutDebug.h
+++ b/FLKAutoLayout/Private/NSLayoutConstraint+FLKAutoLayoutDebug.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface NSLayoutConstraint (FLKAutoLayoutDebug)
 

--- a/FLKAutoLayout/Private/UIView+FLKAutoLayoutPredicate.h
+++ b/FLKAutoLayout/Private/UIView+FLKAutoLayoutPredicate.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 typedef struct {
     NSLayoutRelation relation;

--- a/FLKAutoLayout/UIView+FLKAutoLayout.h
+++ b/FLKAutoLayout/UIView+FLKAutoLayout.h
@@ -1,4 +1,4 @@
-@import UIKit;
+#import <UIKit/UIKit.h>
 NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXTERN NSString *const FLKNoConstraint;

--- a/FLKAutoLayout/UIView+FLKAutoLayoutDebug.h
+++ b/FLKAutoLayout/UIView+FLKAutoLayoutDebug.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface UIView (FLKAutoLayoutDebug)
 

--- a/FLKAutoLayout/UIViewController+FLKAutoLayout.h
+++ b/FLKAutoLayout/UIViewController+FLKAutoLayout.h
@@ -1,4 +1,4 @@
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 /// A NSLayoutGuide for iOS 7 & 8
 


### PR DESCRIPTION
In some cases the ```@import``` declarations do not work even if the ```CLANG_ENABLE_MODULES``` is set to ```YES```.